### PR TITLE
Native S3 and WebDAV backends

### DIFF
--- a/ft/CLI/Options.cs
+++ b/ft/CLI/Options.cs
@@ -72,5 +72,27 @@ namespace ft.CLI
 
         [Option("dropbox", Required = false, HelpText = @"Optimize the tunnel for Dropbox")]
         public static bool Dropbox { get; set; } = false;
+
+        //Returns the supplied value if it is non-empty, otherwise the first non-empty environment
+        //variable from the supplied names. Lets secrets be passed via the environment instead of the
+        //command line, so they don't appear in the process list.
+        protected static string ResolveWithEnv(string value, params string[] environmentVariableNames)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            foreach (var environmentVariableName in environmentVariableNames)
+            {
+                var fromEnvironment = Environment.GetEnvironmentVariable(environmentVariableName);
+                if (!string.IsNullOrEmpty(fromEnvironment))
+                {
+                    return fromEnvironment;
+                }
+            }
+
+            return value;
+        }
     }
 }

--- a/ft/CLI/S3Options.cs
+++ b/ft/CLI/S3Options.cs
@@ -20,13 +20,20 @@ namespace ft.CLI
         [Option("endpoint", Required = false, HelpText = @"The S3 endpoint URL. Omit for AWS S3 (derived from --region), or specify for S3-compatible services. Example: --endpoint https://minio.example.com")]
         public string Endpoint { get; set; } = "";
 
-        [Option("access-key", Required = true, HelpText = @"The S3 access key ID.")]
+        [Option("access-key", Required = false, HelpText = @"The S3 access key ID. Alternatively set the FT_S3_ACCESS_KEY environment variable to keep it out of the command line and process list.")]
         public string AccessKey { get; set; } = "";
 
-        [Option("secret-key", Required = true, HelpText = @"The S3 secret access key.")]
+        [Option("secret-key", Required = false, HelpText = @"The S3 secret access key. Alternatively set the FT_S3_SECRET_KEY environment variable to keep it out of the command line and process list.")]
         public string SecretKey { get; set; } = "";
+
+        [Option("max-connections", Required = false, HelpText = @"The maximum number of concurrent HTTP connections to the S3 endpoint. Default 20")]
+        public int MaxConnections { get; set; } = 20;
 
         [Option('m', "max-size", Required = false, HelpText = @"The maximum size (in bytes) the file can be before uploading. Default 102400 (100 KB)")]
         public int MaxFileSizeBytes { get; set; } = 100 * 1024;
+
+        public string ResolveAccessKey() => ResolveWithEnv(AccessKey, "FT_S3_ACCESS_KEY");
+
+        public string ResolveSecretKey() => ResolveWithEnv(SecretKey, "FT_S3_SECRET_KEY");
     }
 }

--- a/ft/CLI/S3Options.cs
+++ b/ft/CLI/S3Options.cs
@@ -1,0 +1,32 @@
+using CommandLine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ft.CLI
+{
+    public class S3Options : Options
+    {
+        [Option("s3-native", Required = false, HelpText = @"Use a native S3 (or S3-compatible) client for the file tunnel. Unlike --s3, this connects directly to the bucket and does not require a mounted file share.")]
+        public bool S3Native { get; set; } = false;
+
+        [Option("bucket", Required = true, HelpText = @"The S3 bucket name.")]
+        public string Bucket { get; set; } = "";
+        [Option("region", Required = false, HelpText = @"The AWS region of the bucket. Example: --region us-east-1 (Default us-east-1)")]
+        public string Region { get; set; } = "us-east-1";
+
+        [Option("endpoint", Required = false, HelpText = @"The S3 endpoint URL. Omit for AWS S3 (derived from --region), or specify for S3-compatible services. Example: --endpoint https://minio.example.com")]
+        public string Endpoint { get; set; } = "";
+
+        [Option("access-key", Required = true, HelpText = @"The S3 access key ID.")]
+        public string AccessKey { get; set; } = "";
+
+        [Option("secret-key", Required = true, HelpText = @"The S3 secret access key.")]
+        public string SecretKey { get; set; } = "";
+
+        [Option('m', "max-size", Required = false, HelpText = @"The maximum size (in bytes) the file can be before uploading. Default 102400 (100 KB)")]
+        public int MaxFileSizeBytes { get; set; } = 100 * 1024;
+    }
+}

--- a/ft/CLI/WebDavOptions.cs
+++ b/ft/CLI/WebDavOptions.cs
@@ -1,0 +1,27 @@
+using CommandLine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ft.CLI
+{
+    public class WebDavOptions : Options
+    {
+        [Option("webdav", Required = false, HelpText = @"Use a WebDAV server for the file tunnel.")]
+        public bool WebDav { get; set; } = false;
+
+        [Option("url", Required = true, HelpText = @"The base URL of the WebDAV server (folder). Example: --url https://example.com/remote.php/dav/files/user/")]
+        public string WebDavUrl { get; set; } = "";
+
+        [Option('u', "username", Required = false, HelpText = @"The username with which to log into the WebDAV server.")]
+        public string WebDavUsername { get; set; } = "";
+
+        [Option('p', "password", Required = false, HelpText = @"The password to log into the WebDAV server.")]
+        public string WebDavPassword { get; set; } = "";
+
+        [Option('m', "max-size", Required = false, HelpText = @"The maximum size (in bytes) the file can be before uploading. Default 102400 (100 KB)")]
+        public int MaxFileSizeBytes { get; set; } = 100 * 1024;
+    }
+}

--- a/ft/CLI/WebDavOptions.cs
+++ b/ft/CLI/WebDavOptions.cs
@@ -15,13 +15,17 @@ namespace ft.CLI
         [Option("url", Required = true, HelpText = @"The base URL of the WebDAV server (folder). Example: --url https://example.com/remote.php/dav/files/user/")]
         public string WebDavUrl { get; set; } = "";
 
-        [Option('u', "username", Required = false, HelpText = @"The username with which to log into the WebDAV server.")]
+        [Option('u', "username", Required = false, HelpText = @"The username with which to log into the WebDAV server. Alternatively set the FT_WEBDAV_USERNAME environment variable.")]
         public string WebDavUsername { get; set; } = "";
 
-        [Option('p', "password", Required = false, HelpText = @"The password to log into the WebDAV server.")]
+        [Option('p', "password", Required = false, HelpText = @"The password to log into the WebDAV server. Alternatively set the FT_WEBDAV_PASSWORD environment variable to keep it out of the command line and process list.")]
         public string WebDavPassword { get; set; } = "";
 
         [Option('m', "max-size", Required = false, HelpText = @"The maximum size (in bytes) the file can be before uploading. Default 102400 (100 KB)")]
         public int MaxFileSizeBytes { get; set; } = 100 * 1024;
+
+        public string ResolveUsername() => ResolveWithEnv(WebDavUsername, "FT_WEBDAV_USERNAME");
+
+        public string ResolvePassword() => ResolveWithEnv(WebDavPassword, "FT_WEBDAV_PASSWORD");
     }
 }

--- a/ft/IO/Files/S3.cs
+++ b/ft/IO/Files/S3.cs
@@ -23,7 +23,7 @@ namespace ft.IO.Files
         readonly string accessKey;
         readonly string secretKey;
 
-        public S3(string endpoint, string region, string bucket, string accessKey, string secretKey)
+        public S3(string endpoint, string region, string bucket, string accessKey, string secretKey, int maxConnections = 20)
         {
             this.region = string.IsNullOrWhiteSpace(region) ? "us-east-1" : region;
             this.bucket = bucket;
@@ -44,8 +44,8 @@ namespace ft.IO.Files
                 PooledConnectionIdleTimeout = TimeSpan.FromSeconds(15),
 
                 //Allow reads, writes and control (ping) traffic to use separate connections concurrently,
-                //so a slow data GET/PUT cannot head-of-line block the others.
-                MaxConnectionsPerServer = 20,
+                //so a slow data GET/PUT cannot head-of-line block the others. Configurable via --max-connections.
+                MaxConnectionsPerServer = maxConnections < 1 ? 1 : maxConnections,
 
                 ConnectTimeout = TimeSpan.FromMilliseconds(Program.UNIVERSAL_TIMEOUT_MS),
             };

--- a/ft/IO/Files/S3.cs
+++ b/ft/IO/Files/S3.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace ft.IO.Files
+{
+    public class S3 : IFileAccess
+    {
+        const string Service = "s3";
+
+        //SHA256 of an empty payload. Used for requests without a body (GET/HEAD/DELETE/COPY).
+        const string EmptyPayloadHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+        readonly HttpClient client;
+        readonly Uri baseUri;
+        readonly string bucket;
+        readonly string region;
+        readonly string accessKey;
+        readonly string secretKey;
+
+        public S3(string endpoint, string region, string bucket, string accessKey, string secretKey)
+        {
+            this.region = string.IsNullOrWhiteSpace(region) ? "us-east-1" : region;
+            this.bucket = bucket;
+            this.accessKey = accessKey;
+            this.secretKey = secretKey;
+
+            if (string.IsNullOrWhiteSpace(endpoint))
+            {
+                endpoint = $"https://s3.{this.region}.amazonaws.com";
+            }
+
+            baseUri = new Uri(endpoint, UriKind.Absolute);
+
+            var handler = new SocketsHttpHandler
+            {
+                //Recycle idle keep-alive sockets. CDN-fronted endpoints (eg. Bunny, Cloud.ru) can leave
+                //stale connections behind that wedge subsequent requests.
+                PooledConnectionIdleTimeout = TimeSpan.FromSeconds(15),
+
+                //Allow reads, writes and control (ping) traffic to use separate connections concurrently,
+                //so a slow data GET/PUT cannot head-of-line block the others.
+                MaxConnectionsPerServer = 20,
+
+                ConnectTimeout = TimeSpan.FromMilliseconds(Program.UNIVERSAL_TIMEOUT_MS),
+            };
+
+            client = new HttpClient(handler)
+            {
+                Timeout = TimeSpan.FromMilliseconds(Program.UNIVERSAL_TIMEOUT_MS),
+            };
+        }
+
+        //Path-style addressing: https://host/bucket/key
+        Uri BuildUri(string path)
+        {
+            var url = $"{baseUri.GetLeftPart(UriPartial.Authority)}{CanonicalUri(path)}";
+            var result = new Uri(url, UriKind.Absolute);
+            return result;
+        }
+
+        string CanonicalUri(string path)
+        {
+            var key = path.Replace('\\', '/').TrimStart('/');
+            var result = $"/{UriEncode(bucket, true)}/{UriEncode(key, false)}";
+            return result;
+        }
+
+        public bool Exists(string path)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Head, BuildUri(path));
+
+            Sign(request, CanonicalUri(path), [], null);
+            using var response = client.Send(request);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return false;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return true;
+        }
+
+        public void Delete(string path)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Delete, BuildUri(path));
+
+            Sign(request, CanonicalUri(path), [], null);
+            using var response = client.Send(request);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return;
+            }
+
+            response.EnsureSuccessStatusCode();
+        }
+
+        public byte[] ReadAllBytes(string path)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, BuildUri(path));
+
+            Sign(request, CanonicalUri(path), [], null);
+            using var response = client.Send(request);
+            response.EnsureSuccessStatusCode();
+
+            using var stream = response.Content.ReadAsStream();
+            using var memoryStream = new MemoryStream();
+            stream.CopyTo(memoryStream);
+            return memoryStream.ToArray();
+        }
+
+        public void WriteAllBytes(string path, byte[] bytes, bool overwrite = true)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Put, BuildUri(path))
+            {
+                Content = new ByteArrayContent(bytes)
+            };
+
+            var signedHeaders = new SortedDictionary<string, string>(StringComparer.Ordinal);
+
+            if (!overwrite)
+            {
+                //"*" means: only succeed if no object currently exists at this key
+                signedHeaders["if-none-match"] = "*";
+            }
+
+            Sign(request, CanonicalUri(path), signedHeaders, bytes);
+            using var response = client.Send(request);
+
+            if (!overwrite && response.StatusCode == HttpStatusCode.PreconditionFailed)
+            {
+                throw new Exception($"{path} exists. Will not overwrite.");
+            }
+
+            response.EnsureSuccessStatusCode();
+        }
+
+        public void Move(string sourceFileName, string destFileName, bool overwrite)
+        {
+            //S3 has no native move: copy the object, then delete the source.
+            using var request = new HttpRequestMessage(HttpMethod.Put, BuildUri(destFileName));
+
+            var signedHeaders = new SortedDictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["x-amz-copy-source"] = CanonicalUri(sourceFileName)
+            };
+
+            if (!overwrite)
+            {
+                signedHeaders["if-none-match"] = "*";
+            }
+
+            Sign(request, CanonicalUri(destFileName), signedHeaders, null);
+            using (var response = client.Send(request))
+            {
+                if (!overwrite && response.StatusCode == HttpStatusCode.PreconditionFailed)
+                {
+                    throw new Exception($"{destFileName} exists. Will not overwrite.");
+                }
+
+                response.EnsureSuccessStatusCode();
+            }
+
+            Delete(sourceFileName);
+        }
+
+        public long GetFileSize(string path)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Head, BuildUri(path));
+
+            Sign(request, CanonicalUri(path), [], null);
+            using var response = client.Send(request);
+            response.EnsureSuccessStatusCode();
+
+            var result = response.Content.Headers.ContentLength ?? 0L;
+            return result;
+        }
+
+        //Signs the request using AWS Signature Version 4 and applies the required headers.
+        //additionalSignedHeaders are both included in the signature and sent on the request.
+        void Sign(HttpRequestMessage request, string canonicalUri, SortedDictionary<string, string> additionalSignedHeaders, byte[]? payload)
+        {
+            var now = DateTime.UtcNow;
+            var amzDate = now.ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture);
+            var dateStamp = now.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+
+            var payloadHash = payload == null ? EmptyPayloadHash : Sha256Hex(payload);
+
+            var host = request.RequestUri!.IdnHost;
+            if (!request.RequestUri.IsDefaultPort)
+            {
+                host += ":" + request.RequestUri.Port;
+            }
+
+            var headers = new SortedDictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["host"] = host,
+                ["x-amz-content-sha256"] = payloadHash,
+                ["x-amz-date"] = amzDate,
+            };
+
+            foreach (var kvp in additionalSignedHeaders)
+            {
+                headers[kvp.Key] = kvp.Value;
+                request.Headers.TryAddWithoutValidation(kvp.Key, kvp.Value);
+            }
+
+            var canonicalHeaders = new StringBuilder();
+            foreach (var kvp in headers)
+            {
+                canonicalHeaders.Append(kvp.Key).Append(':').Append(kvp.Value.Trim()).Append('\n');
+            }
+
+            var signedHeaders = string.Join(";", headers.Keys);
+
+            var canonicalRequest =
+                request.Method.Method + "\n" +
+                canonicalUri + "\n" +
+                "" + "\n" +                     //no query string for these operations
+                canonicalHeaders + "\n" +
+                signedHeaders + "\n" +
+                payloadHash;
+
+            var credentialScope = $"{dateStamp}/{region}/{Service}/aws4_request";
+
+            var stringToSign =
+                "AWS4-HMAC-SHA256\n" +
+                amzDate + "\n" +
+                credentialScope + "\n" +
+                Sha256Hex(Encoding.UTF8.GetBytes(canonicalRequest));
+
+            var signingKey = GetSigningKey(dateStamp);
+            var signature = Convert.ToHexString(HmacSha256(signingKey, stringToSign)).ToLowerInvariant();
+
+            var authorization = $"AWS4-HMAC-SHA256 Credential={accessKey}/{credentialScope}, SignedHeaders={signedHeaders}, Signature={signature}";
+
+            request.Headers.TryAddWithoutValidation("x-amz-date", amzDate);
+            request.Headers.TryAddWithoutValidation("x-amz-content-sha256", payloadHash);
+            request.Headers.TryAddWithoutValidation("Authorization", authorization);
+        }
+
+        byte[] GetSigningKey(string dateStamp)
+        {
+            var kDate = HmacSha256(Encoding.UTF8.GetBytes("AWS4" + secretKey), dateStamp);
+            var kRegion = HmacSha256(kDate, region);
+            var kService = HmacSha256(kRegion, Service);
+            var kSigning = HmacSha256(kService, "aws4_request");
+            return kSigning;
+        }
+
+        static byte[] HmacSha256(byte[] key, string data)
+        {
+            var result = HMACSHA256.HashData(key, Encoding.UTF8.GetBytes(data));
+            return result;
+        }
+
+        static string Sha256Hex(byte[] data)
+        {
+            var result = Convert.ToHexString(SHA256.HashData(data)).ToLowerInvariant();
+            return result;
+        }
+
+        //URI-encodes per RFC 3986 as required by AWS SigV4 (encodes every byte except unreserved chars).
+        static string UriEncode(string value, bool encodeSlash)
+        {
+            var result = new StringBuilder();
+
+            foreach (var b in Encoding.UTF8.GetBytes(value))
+            {
+                var c = (char)b;
+
+                if (c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9') or '-' or '_' or '.' or '~')
+                {
+                    result.Append(c);
+                }
+                else if (c == '/')
+                {
+                    result.Append(encodeSlash ? "%2F" : "/");
+                }
+                else
+                {
+                    result.Append('%').Append(b.ToString("X2", CultureInfo.InvariantCulture));
+                }
+            }
+
+            return result.ToString();
+        }
+    }
+}

--- a/ft/IO/Files/WebDav.cs
+++ b/ft/IO/Files/WebDav.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace ft.IO.Files
+{
+    public class WebDav : IFileAccess
+    {
+        static readonly HttpMethod MoveMethod = new("MOVE");
+        static readonly HttpMethod PropFindMethod = new("PROPFIND");
+        static readonly XNamespace DavNs = "DAV:";
+
+        readonly HttpClient client;
+        readonly Uri baseUri;
+
+        //HEAD support is a fixed server capability; once we learn it's unsupported, stop trying it
+        bool headSupported = true;
+
+        public WebDav(string url, string username, string password)
+        {
+            if (!url.EndsWith('/'))
+            {
+                url += "/";
+            }
+
+            baseUri = new Uri(url, UriKind.Absolute);
+
+            var handler = new HttpClientHandler
+            {
+                PreAuthenticate = true,     //avoids a 401 challenge round-trip on every request
+            };
+
+            client = new HttpClient(handler)
+            {
+                Timeout = TimeSpan.FromMilliseconds(Program.UNIVERSAL_TIMEOUT_MS),
+            };
+
+            if (!string.IsNullOrEmpty(username))
+            {
+                var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+            }
+        }
+
+        Uri BuildUri(string path)
+        {
+            var relative = path.Replace('\\', '/').TrimStart('/');
+            var result = new Uri(baseUri, relative);
+            return result;
+        }
+
+        public bool Exists(string path)
+        {
+            var uri = BuildUri(path);
+
+            lock (client)
+            {
+                if (!headSupported)
+                {
+                    return PropFindExists(uri);
+                }
+
+                using var request = new HttpRequestMessage(HttpMethod.Head, uri);
+                using var response = client.Send(request);
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return false;
+                }
+
+                if (HeadNotSupported(response.StatusCode))
+                {
+                    headSupported = false;
+                    return PropFindExists(uri);
+                }
+
+                response.EnsureSuccessStatusCode();
+                return true;
+            }
+        }
+
+        public void Delete(string path)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Delete, BuildUri(path));
+
+            lock (client)
+            {
+                using var response = client.Send(request);
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return;
+                }
+
+                response.EnsureSuccessStatusCode();
+            }
+        }
+
+        public byte[] ReadAllBytes(string path)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, BuildUri(path));
+
+            lock (client)
+            {
+                using var response = client.Send(request);
+                response.EnsureSuccessStatusCode();
+
+                using var stream = response.Content.ReadAsStream();
+                using var memoryStream = new MemoryStream();
+                stream.CopyTo(memoryStream);
+                return memoryStream.ToArray();
+            }
+        }
+
+        public void WriteAllBytes(string path, byte[] bytes, bool overwrite = true)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Put, BuildUri(path))
+            {
+                Content = new ByteArrayContent(bytes)
+            };
+
+            if (!overwrite)
+            {
+                //"*" means: only succeed if no entity currently exists at this URL
+                request.Headers.IfNoneMatch.Add(EntityTagHeaderValue.Any);
+            }
+
+            lock (client)
+            {
+                using var response = client.Send(request);
+
+                if (!overwrite && response.StatusCode == HttpStatusCode.PreconditionFailed)
+                {
+                    throw new Exception($"{path} exists. Will not overwrite.");
+                }
+
+                response.EnsureSuccessStatusCode();
+            }
+        }
+
+        public void Move(string sourceFileName, string destFileName, bool overwrite)
+        {
+            using var request = new HttpRequestMessage(MoveMethod, BuildUri(sourceFileName));
+            request.Headers.Add("Destination", BuildUri(destFileName).AbsoluteUri);
+            request.Headers.Add("Overwrite", overwrite ? "T" : "F");
+
+            lock (client)
+            {
+                using var response = client.Send(request);
+
+                if (!overwrite && response.StatusCode == HttpStatusCode.PreconditionFailed)
+                {
+                    throw new Exception($"{destFileName} exists. Will not overwrite.");
+                }
+
+                response.EnsureSuccessStatusCode();
+            }
+        }
+
+        public long GetFileSize(string path)
+        {
+            var uri = BuildUri(path);
+
+            lock (client)
+            {
+                if (!headSupported)
+                {
+                    return PropFindContentLength(uri);
+                }
+
+                using var request = new HttpRequestMessage(HttpMethod.Head, uri);
+                using var response = client.Send(request);
+
+                if (HeadNotSupported(response.StatusCode))
+                {
+                    headSupported = false;
+                    return PropFindContentLength(uri);
+                }
+
+                response.EnsureSuccessStatusCode();
+
+                //some servers omit Content-Length on HEAD; fall back to PROPFIND
+                var result = response.Content.Headers.ContentLength ?? PropFindContentLength(uri);
+                return result;
+            }
+        }
+
+        static bool HeadNotSupported(HttpStatusCode statusCode)
+        {
+            var result = statusCode is HttpStatusCode.MethodNotAllowed or HttpStatusCode.NotImplemented;
+            return result;
+        }
+
+        //caller must hold the lock on client
+        HttpResponseMessage SendPropFind(Uri uri)
+        {
+            const string body = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <D:propfind xmlns:D="DAV:"><D:prop><D:getcontentlength/></D:prop></D:propfind>
+                """;
+
+            var request = new HttpRequestMessage(PropFindMethod, uri)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/xml")
+            };
+            request.Headers.Add("Depth", "0");
+
+            var response = client.Send(request);
+            return response;
+        }
+
+        //caller must hold the lock on client
+        bool PropFindExists(Uri uri)
+        {
+            using var response = SendPropFind(uri);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return false;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return true;
+        }
+
+        //caller must hold the lock on client
+        long PropFindContentLength(Uri uri)
+        {
+            using var response = SendPropFind(uri);
+            response.EnsureSuccessStatusCode();
+
+            using var stream = response.Content.ReadAsStream();
+            var doc = XDocument.Load(stream);
+
+            var contentLengthText = doc
+                .Descendants(DavNs + "getcontentlength")
+                .Select(element => element.Value)
+                .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+
+            var result = long.TryParse(contentLengthText, out var length) ? length : 0L;
+            return result;
+        }
+    }
+}

--- a/ft/Program.cs
+++ b/ft/Program.cs
@@ -30,6 +30,7 @@ namespace ft
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ReusableFileOptions))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(FtpOptions))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(WebDavOptions))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(S3Options))]
         public static void Main(string[] args)
         {
             if (args.Contains("--version"))
@@ -62,6 +63,13 @@ namespace ft
                 parser
                     .ParseArguments<WebDavOptions>(args)
                     .WithParsed(RunWebDavSession)
+                    .WithNotParsed(err => Environment.Exit(1));
+            }
+            else if (args.Contains("--s3-native"))
+            {
+                parser
+                    .ParseArguments<S3Options>(args)
+                    .WithParsed(RunS3Session)
                     .WithNotParsed(err => Environment.Exit(1));
             }
             else
@@ -105,6 +113,21 @@ namespace ft
         private static void RunWebDavSession(WebDavOptions o)
         {
             var access = new WebDav(o.WebDavUrl, o.WebDavUsername, o.WebDavPassword);
+
+            var sharedFileManager = new UploadDownload(
+                                             access,
+                                             o.ReadFrom.Trim(),
+                                             o.WriteTo.Trim(),
+                                             Options.TunnelTimeoutMilliseconds,
+                                             1,
+                                             o.Verbose);
+
+            RunSession(sharedFileManager, o, o.MaxFileSizeBytes);
+        }
+
+        private static void RunS3Session(S3Options o)
+        {
+            var access = new S3(o.Endpoint, o.Region, o.Bucket, o.AccessKey, o.SecretKey);
 
             var sharedFileManager = new UploadDownload(
                                              access,

--- a/ft/Program.cs
+++ b/ft/Program.cs
@@ -29,6 +29,7 @@ namespace ft
 
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ReusableFileOptions))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(FtpOptions))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(WebDavOptions))]
         public static void Main(string[] args)
         {
             if (args.Contains("--version"))
@@ -54,6 +55,13 @@ namespace ft
                 parser
                     .ParseArguments<FtpOptions>(args)
                     .WithParsed(RunFtpSession)
+                    .WithNotParsed(err => Environment.Exit(1));
+            }
+            else if (args.Contains("--webdav"))
+            {
+                parser
+                    .ParseArguments<WebDavOptions>(args)
+                    .WithParsed(RunWebDavSession)
                     .WithNotParsed(err => Environment.Exit(1));
             }
             else
@@ -89,6 +97,21 @@ namespace ft
                                              1,
                                              0,        //no batch cap for FTP: every file is a separate data-connection round-trip on one serialized connection, so fewer/larger files = far less contention (the original behaviour). The 9p cap exists only to avoid torn reads on a coherent local mount.
                                              true,     //FTP: blocking reader - its single serialized FtpClient must stay free for the keep-alive pings (true at any subfile count)
+                                             o.Verbose);
+
+            RunSession(sharedFileManager, o, o.MaxFileSizeBytes);
+        }
+
+        private static void RunWebDavSession(WebDavOptions o)
+        {
+            var access = new WebDav(o.WebDavUrl, o.WebDavUsername, o.WebDavPassword);
+
+            var sharedFileManager = new UploadDownload(
+                                             access,
+                                             o.ReadFrom.Trim(),
+                                             o.WriteTo.Trim(),
+                                             Options.TunnelTimeoutMilliseconds,
+                                             1,
                                              o.Verbose);
 
             RunSession(sharedFileManager, o, o.MaxFileSizeBytes);

--- a/ft/Program.cs
+++ b/ft/Program.cs
@@ -120,6 +120,8 @@ namespace ft
                                              o.WriteTo.Trim(),
                                              Options.TunnelTimeoutMilliseconds,
                                              1,
+                                             0,        //remote HTTP transport: no batch cap (like FTP) - whole-object PUT/GET has no torn-read risk, so fewer/larger files = fewer round-trips
+                                             true,     //blocking reader: strict ping-pong over one shared HttpClient (locked), so idle on the read slot to keep the tunnel online without a poll-storm
                                              o.Verbose);
 
             RunSession(sharedFileManager, o, o.MaxFileSizeBytes);
@@ -145,6 +147,8 @@ namespace ft
                                              o.WriteTo.Trim(),
                                              Options.TunnelTimeoutMilliseconds,
                                              1,
+                                             0,        //remote HTTP transport: no batch cap (like FTP) - whole-object PUT/GET has no torn-read risk, so fewer/larger files = fewer round-trips
+                                             true,     //blocking reader: strict ping-pong keeps the tunnel online without hammering the endpoint with 404 polls
                                              o.Verbose);
 
             RunSession(sharedFileManager, o, o.MaxFileSizeBytes);

--- a/ft/Program.cs
+++ b/ft/Program.cs
@@ -112,7 +112,7 @@ namespace ft
 
         private static void RunWebDavSession(WebDavOptions o)
         {
-            var access = new WebDav(o.WebDavUrl, o.WebDavUsername, o.WebDavPassword);
+            var access = new WebDav(o.WebDavUrl, o.ResolveUsername(), o.ResolvePassword());
 
             var sharedFileManager = new UploadDownload(
                                              access,
@@ -127,7 +127,17 @@ namespace ft
 
         private static void RunS3Session(S3Options o)
         {
-            var access = new S3(o.Endpoint, o.Region, o.Bucket, o.AccessKey, o.SecretKey);
+            var accessKey = o.ResolveAccessKey();
+            var secretKey = o.ResolveSecretKey();
+
+            if (string.IsNullOrEmpty(accessKey) || string.IsNullOrEmpty(secretKey))
+            {
+                Log("An S3 access key and secret key are required. Provide them via --access-key / --secret-key, or via the FT_S3_ACCESS_KEY / FT_S3_SECRET_KEY environment variables.", ConsoleColor.Red);
+                Environment.Exit(1);
+                return;
+            }
+
+            var access = new S3(o.Endpoint, o.Region, o.Bucket, accessKey, secretKey, o.MaxConnections);
 
             var sharedFileManager = new UploadDownload(
                                              access,


### PR DESCRIPTION
This PR adds native, opt-in S3 and WebDAV file backends so File-Tunnel can use cloud storage directly instead of going through an rclone mount.

I started this because the rclone mount path was not practical in my testing. With rclone **v1.74.4**, I saw round-trips in the **6.5-16 second** range, aborted downloads, and some backends that never connected at all. I reproduced it on both a Windows 11 home connection and a clean Linux VPS, so this does not look like a local machine issue.

The native backends avoid rclone's VFS polling and directory-listing overhead. A tunnel round-trip is now just the HTTP calls File-Tunnel actually needs.

## Changes

- Added `--s3-native`, a small path-style SigV4 client for S3-compatible storage.
- Added `--webdav`, using direct `GET`, `PUT`, `HEAD`/`PROPFIND`, and `MOVE` requests.
- Kept the existing `--s3` rclone path unchanged to keep backward compatibility.
- Added environment-variable support for secrets: `FT_S3_ACCESS_KEY`, `FT_S3_SECRET_KEY`, `FT_WEBDAV_USERNAME`, and `FT_WEBDAV_PASSWORD`.
- Added `--max-connections` so the S3 connection pool size is configurable.

## Results

In the same test setup, native backends were about **5-18x lower latency** than the rclone mount, and downloads completed in cases where the mount aborted or carried no data. I tested the setup by spawning a local web server and making requests to it with `curl` via FileTunnel. For the latency I measured by fetching a small file (100bytes) 15 times in a row, and a throughput test was a 30 MB file download.

Examples from Windows (home fibre 150/150 mbps, Prague, Czech Republic) testing:

S3:
- AWS S3 ('eu-central-1' region): **6580 ms / aborted** with rclone, **374 ms / 1.88 MiB/s** native.
- Hetzner Object Storage (Nuremberg, Germany): **9617 ms / aborted** with rclone, **523 ms / 0.81 MiB/s** native.
- Cloudflare R2: **7941 ms / 0.57 MiB/s** with rclone, **1287 ms / 0.61 MiB/s** native

WebDAV:
- Nginx WebDAV (VPS server in Riga, Latvia): **8144 ms / 0.18 MiB/s** with rclone, **694 ms / 0.97 MiB/s** native.
- mail.ru cloud (probably Moscow, Russia): **10319 ms / aborted** with rclone, **1815 ms / 0.23 MiB/s** native.

Thanks, @fiddyschmitt, for File-Tunnel. The existing `IFileAccess` abstraction made these backends straightforward to add.
